### PR TITLE
monorepo jest

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -27,7 +27,7 @@ jobs:
     - run: npm run lint-all
     - run: npm run build-all
     - name: Run the tests and generate coverage report
-      run: npm run test-all
+      run: npm run test -- --coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+export default {
+	testEnvironment: 'jsdom',
+	transform: {
+		'^.+\\.tsx?$': 'ts-jest',
+	},
+	moduleNameMapper: {
+		'\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+      "\\.svg": "<rootDir>/client/src/__mocks__/svg.tsx"
+	},
+	setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build-all": "npm run build --workspaces --if-present",
     "lint-all": "npm run lint --workspaces --if-present",
     "test-all": "npm run test --workspaces --if-present",
-    "test-all-cov": "npm run test --workspaces --if-present -- --coverage"
+    "test-all-cov": "npm run test --workspaces --if-present -- --coverage",
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
   },
-  "include": ["src", "client", "server"],
+  "include": ["src", "client", "server", "jest.setup.ts"],
   "ts-node": {
     "esm": true
   },


### PR DESCRIPTION
Makes it easier to test with just a monorepo test setup, and a single coverage folder, rather than multiple per projectp